### PR TITLE
chore: allow dependabot to keep Github Actions in use up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Use Dependabot to keep Github Actions in use in workflows up to date. There is some risk here as they are currently set to auto-merge also and any malicious updates to the actions would likely have adverse effects on the repo. Having said that, there is no auto-release strategy in place so decision is to keep an eye on how this activity performs.