### PR TITLE
fix: currently there are not enough permissions to merge the PR.

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This may be because the workflow is triggered by a dependabot PR and therefore untrusted, or it may just need more permissions. This PR tests the latter case, the former will require a PAT being made available in the environment with sufficient permissions.