### PR TITLE
fix: Use GITHUB_TOKEN for auto-merging Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
 name: Dependabot auto-merge
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write
@@ -14,4 +14,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.AUTOMERGE_PAT}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Use GITHUB_TOKEN because the permissions have been elevated explicitly and standard secrets are not available in Dependabot triggered workflows.

Use pull_request_target out of caution.